### PR TITLE
Modified regex to do lazy matching for correct img link extraction

### DIFF
--- a/Ankier/Ankier.csproj
+++ b/Ankier/Ankier.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.61" />
     <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.6" />
   </ItemGroup>
 

--- a/Mcqer/IndiabixScraper.cs
+++ b/Mcqer/IndiabixScraper.cs
@@ -272,7 +272,7 @@ namespace Mcqer
 			if (string.IsNullOrEmpty(textWithImage))
 				return "";
 
-			Match match = Regex.Match(textWithImage, @"img src=""(.+)""");
+			Match match = Regex.Match(textWithImage, @"img src=""(.+?)""");
 			if (match.Groups.Count == 2)
 			{
 				string encodedImage = GetBase64EncodedImage($"{_rootUrl}{match.Groups[1].Value}");


### PR DESCRIPTION
Added code to wrap <span class="root"> in appropriate MathML elements for correct square root display

Tracked by issue #2 